### PR TITLE
Adds RwLock type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro_types"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 readme = "README.md"
 license-file = "LICENSE.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,12 @@ name = "micro_types"
 version = "0.2.2"
 edition = "2021"
 readme = "README.md"
-license = "MIT"
 license-file = "LICENSE.md"
 description = "Types for distributed systems"
 repository = "https://github.com/rust-micro/types"
 homepage = "https://github.com/rust-micro/types"
 keywords = ["micro", "distributed", "type", "redis"]
-categories = ["microservice", "type", "database"]
+categories = ["network-programming", "data-structures", "database"]
 documentation = "https://docs.rs/micro_types"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/redis/generic.rs
+++ b/src/redis/generic.rs
@@ -18,7 +18,7 @@ pub struct Generic<T> {
 
 impl<T> Generic<T>
 where
-    T: Display + Serialize + DeserializeOwned,
+    T: Serialize + DeserializeOwned,
 {
     /// The new method creates a new instance of the type.
     /// It does not load or store any value in Redis.

--- a/src/redis/list.rs
+++ b/src/redis/list.rs
@@ -31,7 +31,7 @@ where
 {
     /// Creates a new List
     ///
-    /// There is no `with_value` method like [Generic::with_value] because it is not possible to
+    /// There is no `with_value` method like (Generic::with_value)[crate::redis::Generic::with_value] because it is not possible to
     /// provide a good default behaviour in redis. So you have to think about, how you want to handle
     /// already stored values in redis.
     /// If you want a small performance boost, look at [ListCache].

--- a/src/redis/mod.rs
+++ b/src/redis/mod.rs
@@ -21,6 +21,7 @@
 //! # Upcoming Features
 //!
 //! It will be possible to create happens-before relationships between store and load operations like atomic types.
+//! Also it will be possible to create other backends than Redis.
 //!
 //! # Usage
 //!
@@ -36,6 +37,10 @@
 //!
 //! More examples can be found on the doc pages of the types.
 //!
+//! # Custom Types
+//!
+//! It is possible to implement your own complex types by implementing the [BackedType](crate::BackedType) trait.
+//! But it should not be needed as long as your type implements some or all of the various [Ops](https://doc.rust-lang.org/std/ops/index.html) traits.
 mod bool_type;
 mod clock;
 mod generic;
@@ -43,6 +48,7 @@ mod helper;
 mod integer;
 mod list;
 mod mutex;
+mod rwlock;
 mod string;
 
 pub(crate) use helper::apply_operator;
@@ -56,4 +62,5 @@ pub use integer::{
 };
 pub use list::{List, ListCache, ListIter};
 pub use mutex::{Guard, LockError, Mutex};
+pub use rwlock::RwLock;
 pub use string::TString as DString;

--- a/src/redis/mutex.rs
+++ b/src/redis/mutex.rs
@@ -340,7 +340,6 @@ where
     type Target = Generic<T>;
 
     fn deref(&self) -> &Self::Target {
-        // Safety: The very existence of this Guard guarantees that we have exclusive access to the data.
         &self.lock.data
     }
 }
@@ -350,7 +349,6 @@ where
     T: DeserializeOwned + Serialize,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        // Safety: The very existence of this Guard guarantees that we have exclusive access to the data.
         &mut self.lock.data
     }
 }

--- a/src/redis/rwlock/constants.rs
+++ b/src/redis/rwlock/constants.rs
@@ -1,0 +1,121 @@
+/// The read lock script.
+///
+/// Checks if the writer list besides the key is empty.
+/// If it is, the uuid is added to the reader list and true is returned.
+/// Returns false otherwise.
+///
+/// Takes 2 arguments:
+/// 1. The key to lock
+/// 2. The uuid of the lock
+pub const READER_LOCK: &str = r#"
+local writer_len = redis.call("LLEN", ARGV[1] .. ":writer")
+if writer_len == 0 then
+    redis.call("RPUSH", ARGV[1] .. ":reader", ARGV[2])
+    return true
+end
+return false
+"#;
+
+/// The read lock drop script.
+///
+/// Removes the uuid from the reader list.
+///
+/// Takes 2 arguments:
+/// 1. The key to lock
+/// 2. The uuid of the lock
+pub const READER_LOCK_DROP: &str = r#"
+local reader_len = redis.call("LLEN", ARGV[1] .. ":reader")
+if reader_len > 0 then
+    redis.call("LREM", ARGV[1] .. ":reader", 1, ARGV[2])
+    return true
+end
+return false
+"#;
+
+/// The writer lock script.
+///
+/// Checks if the reader and writer list besides the key are empty.
+/// If they are, the uuid is added to the writer list and true is returned.
+/// Returns false otherwise.
+///
+/// Takes 2 arguments:
+/// 1. The key to lock
+/// 2. The uuid of the lock
+pub const WRITER_LOCK: &str = r#"
+local reader_len = redis.call("LLEN", ARGV[1] .. ":reader")
+local writer_len = redis.call("LLEN", ARGV[1] .. ":writer")
+if reader_len == 0 and writer_len == 0 then
+    redis.call("RPUSH", ARGV[1] .. ":writer", ARGV[2])
+    return true
+end
+return false
+"#;
+
+/// The writer lock drop script.
+///
+/// Removes the uuid from the writer list.
+///
+/// Takes 2 arguments:
+/// 1. The key to lock
+/// 2. The uuid of the lock
+pub const WRITER_LOCK_DROP: &str = r#"
+local writer_len = redis.call("LLEN", ARGV[1] .. ":writer")
+if writer_len > 0 then
+    redis.call("LREM", ARGV[1] .. ":writer", 1, ARGV[2])
+    return true
+end
+return false
+"#;
+
+/// The uuid script.
+///
+/// Increments the uuid counter and returns the new value.
+///
+/// Takes 1 argument:
+/// 1. The key to lock
+pub const UUID_SCRIPT: &str = r#"
+redis.call("INCR", ARGV[1] .. ":uuid")
+return redis.call("GET", ARGV[1] .. ":uuid")
+"#;
+
+/// The read script.
+///
+/// Reads the value from the key, only if the uuid is in reader list or if it is the single entry in the writer list.
+///
+/// Takes 2 argument:
+/// 1. The key to read
+/// 2. The uuid of the lock
+pub const READ_SCRIPT: &str = r#"
+local function contains(table, val)
+    for i=1,#table do
+        if table[i] == val then 
+            return true
+        end
+    end
+    return false
+end
+
+local readers = redis.call("LRANGE", ARGV[1] .. ":reader" , 0, -1)
+local writers = redis.call("LRANGE", ARGV[1] .. ":writer" , 0, -1)
+
+if contains(readers, ARGV[2]) or (#writers == 1 and writers[1] == ARGV[2]) then
+    return redis.call("GET", ARGV[1])
+end
+"#;
+
+/// The store script.
+///
+/// Stores the value to the key, only if the uuid is in writer list and the list is only one.
+///
+/// Takes 3 arguments:
+/// 1. The key to store
+/// 2. The uuid of the lock
+/// 3. The value to store
+pub const STORE_SCRIPT: &str = r#"
+local writers = redis.call("LRANGE", ARGV[1] .. ":writer" , 0, -1)
+if #writers == 1 and writers[1] == ARGV[2] then
+    redis.call("SET", ARGV[1], ARGV[3])
+    return true
+end
+return false
+"#;

--- a/src/redis/rwlock/constants.rs
+++ b/src/redis/rwlock/constants.rs
@@ -50,8 +50,9 @@ return 1
 /// 1. The key to lock
 /// 2. The uuid of the lock
 /// 3. The timeout in seconds for waiting
+// TODO: Should lock be expanded, if there is already another writer waiting?
 pub const WRITER_LOCK: &str = r#"
-redis.call("setex", ARGV[1] .. ":writer_waiting_list:" .. ARGV[2], ARGV[3], 1)
+redis.call("set", ARGV[1] .. ":writer_waiting_list:" .. ARGV[2], 1, "ex", ARGV[3])
 if redis.call("exists", ARGV[1] .. ":lock") == 1 then
     return 0
 end

--- a/src/redis/rwlock/constants.rs
+++ b/src/redis/rwlock/constants.rs
@@ -1,19 +1,27 @@
 /// The read lock script.
 ///
-/// Checks if the writer list besides the key is empty.
-/// If it is, the uuid is added to the reader list and true is returned.
+/// Checks if the writer list besides the key is empty or the lock is set.
+/// If there are no writers, the uuid will be set as a reader and returns true.
 /// Returns false otherwise.
 ///
-/// Takes 2 arguments:
+/// The timeout will be used for the reader lock. You need to retry to get the lock again if you want to keep it.
+/// But if a writer comes in scope, the reader lock will be dropped after the timeout and you have to wait.
+///
+/// Takes 3 arguments:
 /// 1. The key to lock
 /// 2. The uuid of the lock
+/// 3. The timeout in seconds
 pub const READER_LOCK: &str = r#"
-local writer_len = redis.call("LLEN", ARGV[1] .. ":writer")
-if writer_len == 0 then
-    redis.call("RPUSH", ARGV[1] .. ":reader", ARGV[2])
-    return true
+if redis.call("exists", ARGV[1] .. ":lock") == 1 then
+    return 0
 end
-return false
+
+local res = redis.call("scan", 0, "match", ARGV[1] .. ":writer_waiting_list:*")
+if next(res[2]) == nil then
+    redis.call("set", ARGV[1] .. ":reader_locks:" .. ARGV[2], 1, "ex", ARGV[3])
+    return 1
+end
+return 0
 "#;
 
 /// The read lock drop script.
@@ -24,31 +32,31 @@ return false
 /// 1. The key to lock
 /// 2. The uuid of the lock
 pub const READER_LOCK_DROP: &str = r#"
-local reader_len = redis.call("LLEN", ARGV[1] .. ":reader")
-if reader_len > 0 then
-    redis.call("LREM", ARGV[1] .. ":reader", 1, ARGV[2])
-    return true
-end
-return false
+redis.call("del", ARGV[1] .. ":reader_locks:" .. ARGV[2])
+return 1
 "#;
 
 /// The writer lock script.
 ///
-/// Checks if the reader and writer list besides the key are empty.
-/// If they are, the uuid is added to the writer list and true is returned.
+/// Checks if the reader list besides the key is empty.
+/// Also add the uuid to the writer waiting list.
+/// If there are no readers, the uuid will be set as the lock and returns true.
 /// Returns false otherwise.
 ///
-/// Takes 2 arguments:
+/// The timeout will also be used for the waiting ticket, so if you wait too long, your intention will be dropped and reader can be acquired.
+/// So be sure to request the lock again fast enough.
+///
+/// Takes 3 arguments:
 /// 1. The key to lock
 /// 2. The uuid of the lock
+/// 3. The timeout in seconds for waiting
 pub const WRITER_LOCK: &str = r#"
-local reader_len = redis.call("LLEN", ARGV[1] .. ":reader")
-local writer_len = redis.call("LLEN", ARGV[1] .. ":writer")
-if reader_len == 0 and writer_len == 0 then
-    redis.call("RPUSH", ARGV[1] .. ":writer", ARGV[2])
-    return true
+redis.call("setex", ARGV[1] .. ":writer_waiting_list:" .. ARGV[2], ARGV[3], 1)
+if redis.call("exists", ARGV[1] .. ":lock") == 1 then
+    return 0
 end
-return false
+
+return redis.call("set", ARGV[1] .. ":lock", ARGV[2], "nx", "ex", ARGV[3])
 "#;
 
 /// The writer lock drop script.
@@ -59,12 +67,11 @@ return false
 /// 1. The key to lock
 /// 2. The uuid of the lock
 pub const WRITER_LOCK_DROP: &str = r#"
-local writer_len = redis.call("LLEN", ARGV[1] .. ":writer")
-if writer_len > 0 then
-    redis.call("LREM", ARGV[1] .. ":writer", 1, ARGV[2])
-    return true
+redis.call("del", ARGV[1] .. ":writer_waiting_list:" .. ARGV[2])
+if redis.call("get", ARGV[1] .. ":lock") == ARGV[2] then
+    redis.call("del", ARGV[1] .. ":lock")
 end
-return false
+return 1
 "#;
 
 /// The uuid script.
@@ -74,48 +81,37 @@ return false
 /// Takes 1 argument:
 /// 1. The key to lock
 pub const UUID_SCRIPT: &str = r#"
-redis.call("INCR", ARGV[1] .. ":uuid")
-return redis.call("GET", ARGV[1] .. ":uuid")
+return redis.call("INCR", ARGV[1] .. ":lock_counter")
 "#;
 
 /// The read script.
 ///
-/// Reads the value from the key, only if the uuid is in reader list or if it is the single entry in the writer list.
+/// Reads the value from the key, only if the uuid is in reader list or if the lock is equal to uuid.
 ///
 /// Takes 2 argument:
 /// 1. The key to read
 /// 2. The uuid of the lock
-pub const READ_SCRIPT: &str = r#"
-local function contains(table, val)
-    for i=1,#table do
-        if table[i] == val then 
-            return true
-        end
-    end
-    return false
+pub const LOAD_SCRIPT: &str = r#"
+if redis.call("get", ARGV[1] .. ":lock") == ARGV[2] then
+    return redis.call("get", ARGV[1])
 end
-
-local readers = redis.call("LRANGE", ARGV[1] .. ":reader" , 0, -1)
-local writers = redis.call("LRANGE", ARGV[1] .. ":writer" , 0, -1)
-
-if contains(readers, ARGV[2]) or (#writers == 1 and writers[1] == ARGV[2]) then
-    return redis.call("GET", ARGV[1])
+if redis.call("exists", ARGV[1] .. ":reader_locks:" .. ARGV[2]) then
+    return redis.call("get", ARGV[1])
 end
 "#;
 
 /// The store script.
 ///
-/// Stores the value to the key, only if the uuid is in writer list and the list is only one.
+/// Stores the value to the key, only if the uuid is in lock.
 ///
 /// Takes 3 arguments:
 /// 1. The key to store
 /// 2. The uuid of the lock
 /// 3. The value to store
 pub const STORE_SCRIPT: &str = r#"
-local writers = redis.call("LRANGE", ARGV[1] .. ":writer" , 0, -1)
-if #writers == 1 and writers[1] == ARGV[2] then
-    redis.call("SET", ARGV[1], ARGV[3])
-    return true
+if redis.call("get", ARGV[1] .. ":lock") == ARGV[2] then
+    redis.call("set", ARGV[1], ARGV[3])
+    return 1
 end
-return false
+return 0
 "#;

--- a/src/redis/rwlock/error.rs
+++ b/src/redis/rwlock/error.rs
@@ -7,4 +7,6 @@ pub enum RwLockError {
     StillReader,
     #[error("The lock could not be dropped.")]
     LockNotDroppable,
+    #[error("The lock is expired. Failed UUID: {0} ")]
+    LockExpired(usize),
 }

--- a/src/redis/rwlock/error.rs
+++ b/src/redis/rwlock/error.rs
@@ -1,0 +1,10 @@
+use thiserror::Error;
+#[derive(Error, Debug)]
+pub enum RwLockError {
+    #[error("The lock is already locked for writer.")]
+    WriterAlreadyLocked,
+    #[error("The lock is already locked for reader.")]
+    StillReader,
+    #[error("The lock could not be dropped.")]
+    LockNotDroppable,
+}

--- a/src/redis/rwlock/lock.rs
+++ b/src/redis/rwlock/lock.rs
@@ -1,0 +1,178 @@
+use super::RwLockReadGuard;
+use super::RwLockWriteGuard;
+use crate::redis::rwlock::constants::{READER_LOCK, UUID_SCRIPT, WRITER_LOCK};
+use crate::redis::{Generic, LockError};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::ops::{Deref, DerefMut};
+
+/// A Read-Write Lock.
+///
+/// This lock is similar to the [std::sync::RwLock](https://doc.rust-lang.org/std/sync/struct.RwLock.html).
+/// But it is distributed over multiple instances of the same service.
+///
+/// # Threads
+///
+/// If you try to get a writer lock in a thread, which already has a reader lock, you will end up in a deadlock.
+/// To use the RwLock in threads, you need a scoped thread.
+///  
+/// # Examples
+///
+/// ## Linear usage
+/// ```
+/// use dtypes::redis::RwLock;
+/// use dtypes::redis::Di32;
+/// use std::thread;
+///
+/// let client = redis::Client::open("redis://localhost:6379").unwrap();
+/// let client2 = client.clone();
+/// let mut i32 = Di32::with_value(1, "test_rwlock_example1", client.clone());
+/// let mut lock = RwLock::new(i32);
+///
+/// {
+///     let read1 = lock.read().unwrap();
+///     let read2 = lock.read().unwrap();
+///     assert_eq!(*read1, 1);
+/// }
+/// {
+///     let mut write1 = lock.write().unwrap();
+///     write1.store(2);
+///     assert_eq!(*write1, 2);
+/// }
+/// {
+///    let mut read1 = lock.read().unwrap();
+///    let read2 = lock.read().unwrap();
+///    assert_eq!(*read1, 2);
+/// }
+/// ```
+/// ## Threaded usage
+/// ```
+/// use dtypes::redis::RwLock;
+/// use dtypes::redis::Di32;
+/// use std::thread;
+///
+/// let client = redis::Client::open("redis://localhost:6379").unwrap();
+/// let i32 = Di32::with_value(1, "test_rwlock_example2", client.clone());
+/// let mut lock = RwLock::new(i32);
+/// assert_eq!(*lock.read().unwrap(), 1);
+/// thread::scope(|s| {
+///        s.spawn(|| {
+///            let mut write = lock.write().unwrap();
+///            write.store(2);
+///            assert_eq!(*write, 2);
+///        }).join().unwrap();
+/// });
+/// assert_eq!(*lock.read().unwrap(), 2);
+/// ```
+pub struct RwLock<T> {
+    pub(crate) data: Generic<T>,
+    writer_wanted: bool,
+}
+
+impl<T> RwLock<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    pub fn new(data: Generic<T>) -> Self {
+        Self {
+            data,
+            writer_wanted: false,
+        }
+    }
+
+    /// Creates a new RwLock Reader.
+    ///
+    /// This function blocks until the lock is acquired.
+    /// If there is a writer lock, this function blocks until the writer lock is dropped.
+    /// Also if there is a writer locks waiting to be acquired, this function blocks until the writer lock is acquired and dropped.
+    pub fn read(&self) -> Result<RwLockReadGuard<T>, LockError> {
+        let uuid = self.generate_uuid();
+        loop {
+            // small performance improvement, because if there is a local writer lock wanted, we don't need to check the remote writer lock
+            if self.writer_wanted {
+                continue;
+            }
+            let res = self.execute_script(&uuid, READER_LOCK);
+            if res {
+                break;
+            }
+        }
+        Ok(RwLockReadGuard::new(self, uuid))
+    }
+
+    /// Creates a new RwLock Writer.
+    ///
+    /// This function blocks until the lock is acquired.
+    /// If there is a reader lock, this function blocks until the reader lock is dropped.
+    /// The acquiring writer lock has priority over any waiting reader lock.
+    pub fn write(&mut self) -> Result<RwLockWriteGuard<T>, LockError> {
+        self.writer_wanted = true;
+        let uuid = self.generate_uuid();
+        loop {
+            let res = self.execute_script(&uuid, WRITER_LOCK);
+            if res {
+                break;
+            }
+        }
+        self.writer_wanted = false;
+        Ok(RwLockWriteGuard::new(self, uuid))
+    }
+
+    fn execute_script(&self, uuid: &usize, script: &str) -> bool {
+        let mut conn = self.data.client.get_connection().unwrap();
+        redis::Script::new(script)
+            .arg(&self.data.key)
+            .arg(uuid)
+            .invoke(&mut conn)
+            .unwrap()
+    }
+
+    pub(crate) fn generate_uuid(&self) -> usize {
+        let mut conn = self.data.client.get_connection().unwrap();
+        redis::Script::new(UUID_SCRIPT)
+            .arg(&self.data.key)
+            .invoke(&mut conn)
+            .unwrap()
+    }
+}
+
+impl<T> Deref for RwLock<T> {
+    type Target = Generic<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl<T> DerefMut for RwLock<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::redis::*;
+    #[test]
+    fn test_rwlock() {
+        use std::thread;
+        use Di32;
+        use RwLock;
+
+        let client = redis::Client::open("redis://localhost:6379").unwrap();
+        let i32 = Di32::with_value(1, "test_rwlock", client.clone());
+        let mut lock = RwLock::new(i32);
+        {
+            let read = lock.read().unwrap();
+            assert_eq!(*read, 1);
+        }
+        {
+            let mut write = lock.write().unwrap();
+            write.store(2);
+            assert_eq!(*write, 2);
+        }
+        let read = lock.read().unwrap();
+        assert_eq!(*read, 2);
+    }
+}

--- a/src/redis/rwlock/mod.rs
+++ b/src/redis/rwlock/mod.rs
@@ -1,0 +1,11 @@
+mod constants;
+mod error;
+mod lock;
+mod reader;
+mod writer;
+
+pub use error::RwLockError;
+pub use lock::RwLock;
+pub use reader::RwLockReadGuard;
+pub use writer::RwLockWriteGuard;
+

--- a/src/redis/rwlock/mod.rs
+++ b/src/redis/rwlock/mod.rs
@@ -8,4 +8,3 @@ pub use error::RwLockError;
 pub use lock::RwLock;
 pub use reader::RwLockReadGuard;
 pub use writer::RwLockWriteGuard;
-

--- a/src/redis/rwlock/reader.rs
+++ b/src/redis/rwlock/reader.rs
@@ -1,0 +1,40 @@
+use super::lock::RwLock;
+use crate::redis::rwlock::constants::READER_LOCK_DROP;
+use crate::redis::Generic;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::ops::Deref;
+
+pub struct RwLockReadGuard<'a, T> {
+    lock: &'a RwLock<T>,
+    uuid: usize,
+}
+
+impl<'a, T> RwLockReadGuard<'a, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    pub(crate) fn new(lock: &'a RwLock<T>, uuid: usize) -> Self {
+        Self { lock, uuid }
+    }
+}
+
+impl<'a, T> Deref for RwLockReadGuard<'a, T> {
+    type Target = Generic<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.lock.data
+    }
+}
+
+impl<T> Drop for RwLockReadGuard<'_, T> {
+    fn drop(&mut self) {
+        let client = self.lock.data.client.clone();
+        let mut conn = client.get_connection().unwrap();
+        let _: () = redis::Script::new(READER_LOCK_DROP)
+            .arg(&self.lock.data.key)
+            .arg(self.uuid)
+            .invoke(&mut conn)
+            .unwrap();
+    }
+}

--- a/src/redis/rwlock/reader.rs
+++ b/src/redis/rwlock/reader.rs
@@ -1,5 +1,5 @@
 use super::lock::RwLock;
-use crate::redis::rwlock::constants::READER_LOCK_DROP;
+use crate::redis::rwlock::constants::{LOAD_SCRIPT, READER_LOCK_DROP};
 use crate::redis::Generic;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -8,14 +8,44 @@ use std::ops::Deref;
 pub struct RwLockReadGuard<'a, T> {
     lock: &'a RwLock<T>,
     uuid: usize,
+    conn: redis::Connection,
+    cache: Option<T>,
 }
 
 impl<'a, T> RwLockReadGuard<'a, T>
 where
     T: Serialize + DeserializeOwned,
 {
-    pub(crate) fn new(lock: &'a RwLock<T>, uuid: usize) -> Self {
-        Self { lock, uuid }
+    pub(crate) fn new(lock: &'a RwLock<T>, uuid: usize, conn: redis::Connection) -> Self {
+        Self {
+            lock,
+            uuid,
+            conn,
+            cache: None,
+        }
+    }
+
+    /// Loads the value from Redis.
+    /// This function blocks until the value is loaded.
+    /// Shadows the load operation of the guarded value.
+    pub fn acquire(&mut self) -> &T {
+        self.cache = self.try_get();
+        self.cache.as_ref().unwrap()
+    }
+
+    fn try_get(&mut self) -> Option<T> {
+        let script = redis::Script::new(LOAD_SCRIPT);
+        let result: Option<String> = script
+            .arg(&self.lock.data.key)
+            .arg(self.uuid)
+            .invoke(&mut self.conn)
+            .expect("Failed to load value. You should not see this!");
+        let result = result?;
+
+        if result == "nil" {
+            return None;
+        }
+        Some(serde_json::from_str(&result).expect("Failed to deserialize value"))
     }
 }
 
@@ -29,8 +59,7 @@ impl<'a, T> Deref for RwLockReadGuard<'a, T> {
 
 impl<T> Drop for RwLockReadGuard<'_, T> {
     fn drop(&mut self) {
-        let client = self.lock.data.client.clone();
-        let mut conn = client.get_connection().unwrap();
+        let mut conn = self.client.get_connection().unwrap();
         let _: () = redis::Script::new(READER_LOCK_DROP)
             .arg(&self.lock.data.key)
             .arg(self.uuid)

--- a/src/redis/rwlock/writer.rs
+++ b/src/redis/rwlock/writer.rs
@@ -34,7 +34,6 @@ impl<'a, T> DerefMut for RwLockWriteGuard<'a, T> {
 
 impl<'a, T> Drop for RwLockWriteGuard<'a, T> {
     fn drop(&mut self) {
-        // FIXME: We have a deadlock, if the Writer will not dropped properly. Same for the reader!
         let client = self.lock.data.client.clone();
         let mut conn = client.get_connection().unwrap();
         let _: () = redis::Script::new(WRITER_LOCK_DROP)

--- a/src/redis/rwlock/writer.rs
+++ b/src/redis/rwlock/writer.rs
@@ -1,0 +1,46 @@
+use crate::redis::rwlock::constants::WRITER_LOCK_DROP;
+use crate::redis::{Generic, RwLock};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::ops::{Deref, DerefMut};
+
+pub struct RwLockWriteGuard<'a, T> {
+    lock: &'a mut RwLock<T>,
+    uuid: usize,
+}
+
+impl<'a, T> RwLockWriteGuard<'a, T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    pub(crate) fn new(lock: &'a mut RwLock<T>, uuid: usize) -> Self {
+        Self { lock, uuid }
+    }
+}
+
+impl<'a, T> Deref for RwLockWriteGuard<'a, T> {
+    type Target = Generic<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.lock.data
+    }
+}
+
+impl<'a, T> DerefMut for RwLockWriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.lock.data
+    }
+}
+
+impl<'a, T> Drop for RwLockWriteGuard<'a, T> {
+    fn drop(&mut self) {
+        // FIXME: We have a deadlock, if the Writer will not dropped properly. Same for the reader!
+        let client = self.lock.data.client.clone();
+        let mut conn = client.get_connection().unwrap();
+        let _: () = redis::Script::new(WRITER_LOCK_DROP)
+            .arg(&self.lock.data.key)
+            .arg(self.uuid)
+            .invoke(&mut conn)
+            .unwrap();
+    }
+}

--- a/src/redis/rwlock/writer.rs
+++ b/src/redis/rwlock/writer.rs
@@ -1,4 +1,5 @@
-use crate::redis::rwlock::constants::WRITER_LOCK_DROP;
+use crate::redis::rwlock::constants::{LOAD_SCRIPT, STORE_SCRIPT, WRITER_LOCK_DROP};
+use crate::redis::rwlock::RwLockError;
 use crate::redis::{Generic, RwLock};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -6,6 +7,7 @@ use std::ops::{Deref, DerefMut};
 
 pub struct RwLockWriteGuard<'a, T> {
     lock: &'a mut RwLock<T>,
+    conn: redis::Connection,
     uuid: usize,
 }
 
@@ -13,8 +15,52 @@ impl<'a, T> RwLockWriteGuard<'a, T>
 where
     T: Serialize + DeserializeOwned,
 {
-    pub(crate) fn new(lock: &'a mut RwLock<T>, uuid: usize) -> Self {
-        Self { lock, uuid }
+    pub(crate) fn new(lock: &'a mut RwLock<T>, uuid: usize, conn: redis::Connection) -> Self {
+        Self { lock, uuid, conn }
+    }
+
+    /// Stores the value in Redis.
+    /// This function blocks until the value is stored.
+    /// Disables the store operation of the guarded value.
+    pub fn store(&mut self, value: T) -> Result<(), RwLockError>
+    where
+        T: Serialize,
+    {
+        let script = redis::Script::new(STORE_SCRIPT);
+        let result: i8 = script
+            .arg(&self.lock.data.key)
+            .arg(self.uuid)
+            .arg(serde_json::to_string(&value).expect("Failed to serialize value"))
+            .invoke(&mut self.conn)
+            .expect("Failed to store value. You should not see this!");
+        if result == 0 {
+            return Err(RwLockError::LockExpired(self.uuid));
+        }
+        self.lock.data.cache = Some(value);
+        Ok(())
+    }
+
+    /// Loads the value from Redis.
+    /// This function blocks until the value is loaded.
+    /// Shadows the load operation of the guarded value.
+    pub fn acquire(&mut self) -> &T {
+        self.lock.data.cache = self.try_get();
+        self.lock.data.cache.as_ref().unwrap()
+    }
+
+    fn try_get(&mut self) -> Option<T> {
+        let script = redis::Script::new(LOAD_SCRIPT);
+        let result: Option<String> = script
+            .arg(&self.lock.data.key)
+            .arg(self.uuid)
+            .invoke(&mut self.conn)
+            .expect("Failed to load value. You should not see this!");
+        let result = result?;
+
+        if result == "nil" {
+            return None;
+        }
+        Some(serde_json::from_str(&result).expect("Failed to deserialize value"))
     }
 }
 
@@ -34,8 +80,7 @@ impl<'a, T> DerefMut for RwLockWriteGuard<'a, T> {
 
 impl<'a, T> Drop for RwLockWriteGuard<'a, T> {
     fn drop(&mut self) {
-        let client = self.lock.data.client.clone();
-        let mut conn = client.get_connection().unwrap();
+        let mut conn = self.client.get_connection().unwrap();
         let _: () = redis::Script::new(WRITER_LOCK_DROP)
             .arg(&self.lock.data.key)
             .arg(self.uuid)


### PR DESCRIPTION
This implements a RwLock type, which is very equal to the std::sync equivalent.

But: there is a deadlock, if you drop a lock inproperly.
Problem is, that we do not have any definition of clock, so timestamp or [ZADD](https://redis.io/commands/zadd/) with value are not a valid option without any modifications.

Test added for this case: https://github.com/rust-micro/types/blob/a5e5d50daddad9299d4d1a312445d9453c869714/src/redis/rwlock/lock.rs#L189


At the end, it could also possible to say: "The user is responsible to deal with such cases"... But then he needs a method to reset everything.

# Idea to implement:

overwrite store and acquire to returns a result and the RwLockError shows, if there is a need to recreate the lock, because it expires. Also replace the list with a redis scheme: <key>:reader:uuid:<uuid> and expiration date of 2 seconds. Like the mutex. Then the user is responsible to recreate the locks and have all tools and informations to do so.

But how to we handle the waiting list for writers? Is It necessary, that the write locks will be granted in the same order as the requests comes in? I think no, because in a distributed manner, we cannot know, if the requests are pushed in the same order as we get them in redis, except we add a request-ordering number. But this adds a new needed request again.
Do we need this assumption? No, because if we have a lock, we need the current wrapped value to calculate. So if the user does not call acquire themself, it could be an old value. (Should be mentioned in doc)
Then we have a pinned time frame to act. (Here we could add an expand method again, like mutex for longer operations.)